### PR TITLE
Fix the crash of demo on iOS 13 and make SceneDelegate conform to UIWindowSceneDelegate

### DIFF
--- a/PodMergeExample/PodMergeExample/SceneDelegate.swift
+++ b/PodMergeExample/PodMergeExample/SceneDelegate.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class SceneDelegate: UIResponder {
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
   var window: UIWindow?
 


### PR DESCRIPTION
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'representation's delegateClass must conform to UISceneDelegate protocol'
***