### PR TITLE
Minimum deployment target

### DIFF
--- a/PodMergeExample/MergeFile
+++ b/PodMergeExample/MergeFile
@@ -12,7 +12,9 @@ end
 
 group 'MergedSwiftPods' do
   pod 'SnapKit', '5.0.1'
+  pod 'Kingfisher', '~> 5.0'
   pod 'SwiftyJSON', '5.0.0'
+  
 end
 
 group 'AlamofireGroup' do

--- a/PodMergeExample/PodMergeExample/ViewController.swift
+++ b/PodMergeExample/PodMergeExample/ViewController.swift
@@ -44,12 +44,17 @@ class ViewController: UIViewController {
 
   let request = ImageRequest(url: URL(string: "https://github.com/grab/cocoapods-pod-merge")!)
 
+  let url = URL(string: "https://example.com/image.png")
+
   override func viewDidLoad() {
     super.viewDidLoad()
 
     // SnapKit Usage
     let box = UIView()
     box.snp.makeConstraints { _ in }
+
+    let imageView = UIImageView(frame: .zero)
+    imageView.kf.setImage(with: url)
   }
 }
 

--- a/PodMergeExample/Podfile.lock
+++ b/PodMergeExample/Podfile.lock
@@ -13,7 +13,7 @@ DEPENDENCIES:
   - UI (from `MergedPods/UI`)
 
 SPEC REPOS:
-  https://cdn.cocoapods.org/:
+  trunk:
     - Nuke
 
 EXTERNAL SOURCES:
@@ -27,11 +27,11 @@ EXTERNAL SOURCES:
     :path: MergedPods/UI
 
 SPEC CHECKSUMS:
-  AlamofireGroup: 113f3ab321b31b75a748378909f3f96305b771a2
-  MergedSwiftPods: 86f52fdd7411987cd39e6c80e709ef0de0126fd3
-  Networking: 844633d13d2328a829083b24ffaee99aea51c1de
+  AlamofireGroup: c7af15f9d1f646dd2d5793dd470efc1942bfc20b
+  MergedSwiftPods: 90c36ec9c0177f0cd19776a428e6e22d6df267a4
+  Networking: 63b67ccfde89eaf06f6e01218d294ec2c8b6c628
   Nuke: 85fb80f8df0cb26c28d2f4e0cb7fb93bcd6548d3
-  UI: 2aa82721ee430cd2f0ab314904bbe1a281fa2ff9
+  UI: 82623fb675f17ffe5a5cd00602619ee4f2040cd7
 
 PODFILE CHECKSUM: 88ffe01efb39e0f819cf88bf11786182ab6f4441
 

--- a/README.md
+++ b/README.md
@@ -245,10 +245,9 @@ This plugin is not a magic bullet that'll merge all your cocoapods into a single
 * **Refrain from merging complex or specialized pods** (like pods written in C/C++). Such pods can have special build settings and compiler flags that can break the other pods that are merged with them.
 * **Make sure** you add the required [flags](https://github.com/grab/cocoapods-pod-merge#special-flags) to relevant groups in your `MergeFile`.
 
-
 ## Troubleshooting
 
-If the above guidelines still do not solve your problem, please [report it](https://github.com/grab/cocoapods-pod-merge/issues)! Merging Pods is a complex process, and the plugin does not cover all possible use cases or podspec formats. Any feedback or feature suggesions are also encouraged. Bug reports and pull requests are welcome. 
+If the above guidelines still do not solve your problem, please [report it](https://github.com/grab/cocoapods-pod-merge/issues)! Merging Pods is a complex process, and the plugin does not cover all possible use cases or podspec formats. Any feedback or feature suggestions are also encouraged. Bug reports and pull requests are welcome.
 
 ## License
 

--- a/lib/cocoapods-pod-merge/Main.rb
+++ b/lib/cocoapods-pod-merge/Main.rb
@@ -337,7 +337,7 @@ module CocoapodsPodMerge
 
       # Create the local podspec
       Pod::UI.puts "\tCreating Podspec for the merged framework".magenta
-      create_podspec(merged_framework_name, pods_to_merge, PodspecInfo.new(frameworks.uniq, prefix_header_contents.uniq, private_header_files.uniq, resources.uniq, script_phases.uniq, compiler_flags.uniq, libraries.uniq, prepare_command.uniq, resource_bundles, vendored_libraries.uniq, swift_version), mixed_language_group)
+      create_podspec(merged_framework_name, pods_to_merge, PodspecInfo.new(frameworks.uniq, prefix_header_contents.uniq, private_header_files.uniq, resources.uniq, script_phases.uniq, compiler_flags.uniq, libraries.uniq, prepare_command.uniq, resource_bundles, vendored_libraries.uniq, swift_version), mixed_language_group, podfile_info)
 
       Pod::UI.puts 'Cleaning up cache'.cyan
       FileUtils.rm_rf(CacheDirectory)
@@ -487,7 +487,7 @@ module CocoapodsPodMerge
       module_map.close
     end
 
-    def create_podspec(merged_framework_name, pods_to_merge, podspec_info, mixed_language_group)
+    def create_podspec(merged_framework_name, pods_to_merge, podspec_info, mixed_language_group, podfile_info)
       frameworks = podspec_info.frameworks
       prefix_header_contents = podspec_info.prefix_header_contents
       private_header_files = podspec_info.private_header_files
@@ -499,6 +499,7 @@ module CocoapodsPodMerge
       resource_bundles = podspec_info.resource_bundles
       vendored_libraries = podspec_info.vendored_libraries
       swift_versions = podspec_info.swift_versions
+      ios_deployment_target = podfile_info.platforms.find { |platform| platform.include? "ios"}.split(',')[1]
 
       mergedPodspec = %(
         Pod::Spec.new do |s|
@@ -510,7 +511,7 @@ module CocoapodsPodMerge
           s.license          = { :type => 'MIT', :text => 'Merged Pods by cocoapods-pod-merge plugin  ' }
           s.author           = { 'GrabTaxi Pte Ltd' => 'dummy@grabtaxi.com' }
           s.source           = { :git => 'https://github.com/grab/cocoapods-pod-merge', :tag => '1.0.0' }
-          s.ios.deployment_target = '8.0'
+          s.ios.deployment_target = #{ios_deployment_target}
           s.source_files = 'Sources/**/*.{h,m,mm,swift}'
         )
 


### PR DESCRIPTION
Hey there 👋. Thanks for the creation of this plugin it's really promising!  

This is PR is focused on fixing an issue with the minimum deployment target in the `*.podspec` for the generated groups. In the plugin, this was hardcoded to `s.ios.deployment_target = '8.0'` causing that the inclusion of libraries with a higher deployment target would generate a compilation error. You can see the example library added in the `PodMergeExample` (**Kingfisher**).

To solve this I used the `platform :ios, 'x.y'` declared in the `Podfile`. This should reflect the minimum deployment target for the Pods project. It's worth to mention that the `Podfile` may have been parsed using the `CocoaPods Core` gem already available avoiding the manual parsing and regex, with something like this:

```ruby
podfile = Pod::Podfile.from_file("Podfile")
sources = podfile.sources
    
podfile.root_target_definitions.each do |target|
    platforms.append(target.platform.to_s)
end
```

I leave as it was to avoid possibles issues in other parts of the plugin.

So this PR can be resumed in the following:

* Update the `ios.deployment_target` from the `Podfile`.
* Fix a misspelling in the README.