### PR TITLE
Subspecs support on the MergeFile

### DIFF
--- a/PodMergeExample/MergeFile
+++ b/PodMergeExample/MergeFile
@@ -29,5 +29,5 @@ end
 
 group 'Subspecs'
     pod 'AppAuth/Core'
-	pod 'AppAuth/ExternalUserAgent'
+    pod 'AppAuth/ExternalUserAgent'
 end

--- a/PodMergeExample/MergeFile
+++ b/PodMergeExample/MergeFile
@@ -26,3 +26,8 @@ group 'AlamofireGroup' do
 	pod 'AlamofireImage', '3.6.0'
 	pod 'AlamofireActivityLogger', '2.5.0'
 end
+
+group 'Subspecs'
+    pod 'AppAuth/Core'
+	pod 'AppAuth/ExternalUserAgent'
+end

--- a/PodMergeExample/MergeFile
+++ b/PodMergeExample/MergeFile
@@ -13,8 +13,11 @@ end
 
 group 'MergedSwiftPods' do
   # Swift Pods
+  swift_version! '5.0'
+  
   pod 'SnapKit', '5.0.1'
   pod 'SwiftyJSON', '5.0.0'
+  pod 'youtube-ios-player-helper'
 end
 
 group 'AlamofireGroup' do

--- a/PodMergeExample/PodMergeExample/ViewController.swift
+++ b/PodMergeExample/PodMergeExample/ViewController.swift
@@ -16,6 +16,7 @@ import UI.TTTAttributedLabel
 
 import Networking.AFNetworking
 import Networking.SDWebImage
+import Subspecs.AppAuth
 
 // Merged Swift Pods cannot be import individually, only all or none.
 import MergedSwiftPods
@@ -50,6 +51,11 @@ class ViewController: UIViewController {
     // SnapKit Usage
     let box = UIView()
     box.snp.makeConstraints { _ in }
+    
+    let authorizationEndpoint = URL(string: "https://accounts.google.com/o/oauth2/v2/auth")!
+    let tokenEndpoint = URL(string: "https://www.googleapis.com/oauth2/v4/token")!
+    let configuration = OIDServiceConfiguration(authorizationEndpoint: authorizationEndpoint,
+                                                tokenEndpoint: tokenEndpoint)
   }
 }
 

--- a/PodMergeExample/Podfile
+++ b/PodMergeExample/Podfile
@@ -13,4 +13,5 @@ target 'PodMergeExample' do
   pod 'UI', :path => 'MergedPods/UI'
   pod 'AlamofireGroup', :path => 'MergedPods/AlamofireGroup'
   pod 'MergedSwiftPods', :path => 'MergedPods/MergedSwiftPods'
+  pod 'Subspecs', :path => 'MergedPods/Subspecs'
 end

--- a/PodMergeExample/Podfile.lock
+++ b/PodMergeExample/Podfile.lock
@@ -32,7 +32,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AlamofireGroup: 113f3ab321b31b75a748378909f3f96305b771a2
-  MergedSwiftPods: 86f52fdd7411987cd39e6c80e709ef0de0126fd3
+  MergedSwiftPods: 1d3174c8375d5c332021c20accaedaf11b5e58d0
   Networking: 844633d13d2328a829083b24ffaee99aea51c1de
   Nuke: 85fb80f8df0cb26c28d2f4e0cb7fb93bcd6548d3
   Subspecs: 634e12dffc5b250b231410781ffa7b7c2c665b7a

--- a/PodMergeExample/Podfile.lock
+++ b/PodMergeExample/Podfile.lock
@@ -3,6 +3,7 @@ PODS:
   - MergedSwiftPods (1.0.0)
   - Networking (1.0.0)
   - Nuke (8.3.1)
+  - Subspecs (1.0.0)
   - UI (1.0.0)
 
 DEPENDENCIES:
@@ -10,6 +11,7 @@ DEPENDENCIES:
   - MergedSwiftPods (from `MergedPods/MergedSwiftPods`)
   - Networking (from `MergedPods/Networking`)
   - Nuke
+  - Subspecs (from `MergedPods/Subspecs`)
   - UI (from `MergedPods/UI`)
 
 SPEC REPOS:
@@ -23,6 +25,8 @@ EXTERNAL SOURCES:
     :path: MergedPods/MergedSwiftPods
   Networking:
     :path: MergedPods/Networking
+  Subspecs:
+    :path: MergedPods/Subspecs
   UI:
     :path: MergedPods/UI
 
@@ -31,8 +35,9 @@ SPEC CHECKSUMS:
   MergedSwiftPods: 86f52fdd7411987cd39e6c80e709ef0de0126fd3
   Networking: 844633d13d2328a829083b24ffaee99aea51c1de
   Nuke: 85fb80f8df0cb26c28d2f4e0cb7fb93bcd6548d3
+  Subspecs: 634e12dffc5b250b231410781ffa7b7c2c665b7a
   UI: 2aa82721ee430cd2f0ab314904bbe1a281fa2ff9
 
-PODFILE CHECKSUM: 689012d73798a7fea312905128d4dadb72554cf1
+PODFILE CHECKSUM: cf932697df9d1e546ce24dd892661e3d0e6d57ec
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
Hey 👋 !  This PR is focused on add support for Subspecs in the `MergeFile`. 

The issue was the `Subspecs` were treated as they were by the plugin. If `AppAuth/Core` was added to the `MergeFile` the plugin was expecting a folder called `AppAuth/Core` would exist and this is not how this is handled. Two specific changes were made to support this:

1. Remove the subspecies from the original list of Pods to verify with folders, for example `AppAuth/Core` will be `AppAuth` only.
2. When the the Podspecs are extracted the Subspecs names are `AppAuth_Core` so it's necessary to keep control of the original list to replace it and add the corresponding Podspecs.

This PR can be resumed in the following:
* Add support for Subspecs on the `MergeFile`.
* Add a new Subspecs group to the `MergeFile` to test the functionality,
* Add a new code to test the Subspecs group.

Closes #11 